### PR TITLE
改进错误提示信息，修复没有re的错误

### DIFF
--- a/bpftUI.py
+++ b/bpftUI.py
@@ -5,6 +5,7 @@ import time
 import webbrowser
 import zlib
 import os
+import re
 # noinspection PyCompatibility
 from tkinter import *
 
@@ -243,6 +244,11 @@ def main():
         if cookie.find('BAIDUID=') == -1:
             label_state_change(state='error')
             text_logs.insert(END, '百度网盘cookie输入不正确,请检查cookie后重试.' + '\n')
+            sys.exit()
+        
+        if any([ord(s) not in range(256) for s in cookie]):
+            label_state_change(state='error')
+            text_logs.insert(END, '百度网盘cookie输入不正确,拷贝的cookie中有非法字符。\n    Firefox等浏览器在长cookie时，会有省略号，是否拷贝全面？.' + '\n')
             sys.exit()
 
         # 执行获取bdstoken


### PR DESCRIPTION
1. import re，使得其可以直接python运行。
2. 增加错误判断：cookie中是否有非ascii字符。这是由于浏览器cookie拷贝不全时，报错信息很难看懂（提示编码错误）


之前在cookie中有`…`时，会提示编码错误
```

File "/usr/lib/python3.5/http/client.py", line 1146, in _send_request
self.putheader(hdr, value)
File "/usr/lib/python3.5/http/client.py", line 1078, in putheader
values[i] = one_value.encode('latin-1')
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2026' in position 30: ordinal not in range(256)
```

相关参考信息：
https://www.cnblogs.com/TOM666/p/12874719.html